### PR TITLE
Fixing queries updates to BreakpointMatchers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,4 @@
 {
-  "extends": "vtex"
+  "extends": "vtex",
+  "root": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Using breakpoint matcher for a query that was added after the first render
 
 ## [0.4.0] - 2020-12-10
 ### Fixed

--- a/react/__tests__/useMediaQueryList.test.tsx
+++ b/react/__tests__/useMediaQueryList.test.tsx
@@ -114,3 +114,27 @@ test('updates the matched list after a media listener is triggered', () => {
     ['(min-width: 1200px)', false],
   ])
 })
+
+test('returns an updated list of media queries after the hook params changes', () => {
+  const initialQueries: string[] = []
+
+  mockMatchMedia({
+    matchedQueries: ['(max-width: 800px)'],
+  })
+
+  const { result, rerender } = renderHook<HookArgs, HookReturnType>(
+    (hookArgs) => useMediaQueryList(hookArgs),
+    { initialProps: initialQueries }
+  )
+
+  expect(result.current.mediaQueries).toMatchObject([])
+
+  const rerenderQueries = ['(max-width: 600px)', '(max-width: 800px)']
+
+  rerender(rerenderQueries)
+
+  expect(result.current.mediaQueries).toMatchObject([
+    ['(max-width: 600px)', false],
+    ['(max-width: 800px)', true],
+  ])
+})

--- a/react/hooks/useMediaQueryList.ts
+++ b/react/hooks/useMediaQueryList.ts
@@ -38,6 +38,13 @@ export function useMediaQueryList(queries: string[]) {
         let mounted = true
         const mediaQueryList = getBreakpointMatcher(query)
 
+        if (matches[query] === undefined || matches[query] === null) {
+          setMatches((curMatches) => ({
+            ...curMatches,
+            [query]: Boolean(mediaQueryList.matches),
+          }))
+        }
+
         const listener = (e: MediaQueryListEvent) => {
           if (!mounted) return
           setMatches((curMatches) => ({ ...curMatches, [query]: e.matches }))

--- a/react/hooks/useMediaQueryList.ts
+++ b/react/hooks/useMediaQueryList.ts
@@ -8,20 +8,21 @@ export function clearMatchersCache() {
   )
 }
 
+function getBreakpointMatcher(query: string) {
+  if (!BreakpointMatchers[query]) {
+    // ugly side-effect to get a up-to-date initial value（＞д＜）
+    BreakpointMatchers[query] = window.matchMedia(query)
+  }
+
+  return BreakpointMatchers[query]
+}
+
 export function useMediaQueryList(queries: string[]) {
   const [matches, setMatches] = useState<Record<string, boolean>>(() => {
     const initial: Record<string, boolean> = {}
 
     queries.forEach((query) => {
-      let mediaQueryList = BreakpointMatchers[query]
-
-      if (!mediaQueryList) {
-        // ugly side-effect to get a up-to-date initial value（＞д＜）
-        mediaQueryList = window.matchMedia(query)
-        BreakpointMatchers[query] = mediaQueryList
-      }
-
-      initial[query] = Boolean(mediaQueryList.matches)
+      initial[query] = Boolean(getBreakpointMatcher(query).matches)
     })
 
     return initial
@@ -35,7 +36,7 @@ export function useMediaQueryList(queries: string[]) {
 
       const cancels = queries.map((query) => {
         let mounted = true
-        const mediaQueryList = BreakpointMatchers[query]
+        const mediaQueryList = getBreakpointMatcher(query)
 
         const listener = (e: MediaQueryListEvent) => {
           if (!mounted) return


### PR DESCRIPTION
#### What problem is this solving?

This PR solves a very specific bug: when the definition for a responsive value changes to a more complex one with `queries`, say, from:


 ```json
{
    "itemsPerRow": 1
}
```

**to**

 ```jsonc
{
    "itemsPerRow": {
            "(min-width:1300px)": 4, //This is a query
            "desktop": 3,
            "tablet": 3,
            "phone": 2
    }
}
```

the `BreakpointMatchers` variable present on the `useMediaQueryList` hook wouldn't be updated with this change, which caused the hook to try to add a listener to an `undefined` value, thus breaking the component.

This was also caused by the `() => { ... }` present on the `useState` call inside the hook mentioned above, which asserted that the initial value function would only run once (on the first render), preventing the `BreakpointMatchers` variable to be updated. The removal of this behavior was not necessary with this solution, which I think is more speedy.

#### How to test it?

After you load the page, try changing the gallery layout to Grid mode.

[Breaking workspace](https://icarorv--storecomponents.myvtex.com/apparel---accessories/?layout=list)

[Healthy workspace](https://icarosearch--storecomponents.myvtex.com/apparel---accessories/?layout=list)

#### Screenshots or example usage:
Image of the bug
<img width="704" alt="Screen Shot 2021-01-06 at 19 55 34" src="https://user-images.githubusercontent.com/8127610/103828108-2780dc80-5059-11eb-9457-c9fdbf02110a.png">

#### Describe alternatives you've considered, if any.

I considered removing the anonymous function from the `useState` hook, but I was afraid it would hurt performance.

#### Related to / Depends on

Related to [store-theme#240](https://github.com/vtex-apps/store-theme/pull/240)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/fefZ2NUMZmIjWNokVi/source.gif)
